### PR TITLE
NGSTACK-529 update ngrm dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "netgen/layouts-ezplatform": "^1.2",
-        "netgen/remote-media-bundle": "dev-master"
+        "netgen/remote-media-bundle": "^2.0@alpha"
     },
     "require-dev": {
         "netgen/layouts-coding-standard": "^1.0 || ^2.0",


### PR DESCRIPTION
Let's set it temporary to 2.0@alpha, so we can test everything in package.
This will soon be changed to require `^2.0`.