### PR TITLE
Add parameter for root folder limitation in the content browser tree v2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,6 +40,28 @@ netgen_layouts_remote_media:
 
 Above shown are the default used parameters. For more information about creating and configuring cache pools, see https://symfony.com/doc/current/cache.html.
 
+### Root folder configuration
+
+This integration also contains the integration for content browser, and the left tree is used to browse
+through folders on the selected provider (eg. Cloudinary).
+
+If you don't want to expose all folders available, this parameter allows you to configure the root folder,
+so that you can see only folders that are below that one.
+
+**NOTE:** this only limits the access to folders in the left tree, but it doesn't prevent you to access
+resources outside of this configured folder - you can still find it via search.
+
+```yaml
+netgen_layouts_remote_media:
+    root_folder: "images/layouts"
+```
+
+By default, this parameter is empty (null) so it will fetch all folders.
+
+**IMPORTANT:** when using Cloudinary provider, content browser's folder tree is doing lots of heavy queries to
+the API in the background. If you have lots of folders in the root, using this parameter might be
+mandatory, to prevent timeouts or breaking API limits.
+
 ## Import database tables
 
 This bundle stores used resources in a separate table in the database. Use the following command to update your database:

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -17,6 +17,7 @@ final class Configuration implements ConfigurationInterface
         /** @var \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $rootNode */
         $rootNode = $treeBuilder->getRootNode();
         $this->addCacheConfiguration($rootNode);
+        $this->addRootFolderConfiguration($rootNode);
 
         return $treeBuilder;
     }
@@ -37,6 +38,17 @@ final class Configuration implements ConfigurationInterface
                             ->defaultValue(7200)
                         ->end()
                     ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addRootFolderConfiguration(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->scalarNode('root_folder')
+                    ->info('Root folder in Cloudinary for content browser (see README)')
+                    ->defaultNull()
                 ->end()
             ->end();
     }

--- a/bundle/DependencyInjection/NetgenLayoutsRemoteMediaExtension.php
+++ b/bundle/DependencyInjection/NetgenLayoutsRemoteMediaExtension.php
@@ -48,6 +48,11 @@ final class NetgenLayoutsRemoteMediaExtension extends Extension implements Prepe
             $config['cache']['ttl'],
         );
 
+        $container->setParameter(
+            'netgen_layouts.remote_media.root_folder',
+            $config['root_folder'],
+        );
+
         $loader->load('default_parameters.yaml');
         $loader->load('services/**/*.yaml', 'glob');
     }

--- a/bundle/Resources/config/services/content_browser.yaml
+++ b/bundle/Resources/config/services/content_browser.yaml
@@ -14,6 +14,7 @@ services:
             - "@netgen_layouts.remote_media.next_cursor_resolver"
             - "@translator"
             - "@netgen_content_browser.config.remote_media"
+            - "%netgen_layouts.remote_media.root_folder%"
         tags:
             - { name: netgen_content_browser.backend, item_type: remote_media }
 

--- a/lib/ContentBrowser/Backend/RemoteMediaBackend.php
+++ b/lib/ContentBrowser/Backend/RemoteMediaBackend.php
@@ -36,6 +36,7 @@ final class RemoteMediaBackend implements BackendInterface
         private NextCursorResolverInterface $nextCursorResolver,
         private TranslatorInterface $translator,
         private Configuration $config,
+        private ?string $rootFolder = null,
     ) {}
 
     public function getSections(): iterable
@@ -242,6 +243,7 @@ final class RemoteMediaBackend implements BackendInterface
             Location::createAsSection(
                 Location::RESOURCE_TYPE_ALL,
                 $this->translator->trans('backend.remote_media.resource_type.' . Location::RESOURCE_TYPE_ALL, [], 'ngcb'),
+                $this->rootFolder,
             ),
         ];
 
@@ -249,6 +251,7 @@ final class RemoteMediaBackend implements BackendInterface
             $sections[] = Location::createAsSection(
                 $type,
                 $this->translator->trans('backend.remote_media.resource_type.' . $type, [], 'ngcb'),
+                $this->rootFolder,
             );
         }
 

--- a/lib/ContentBrowser/Item/RemoteMedia/Location.php
+++ b/lib/ContentBrowser/Item/RemoteMedia/Location.php
@@ -15,6 +15,7 @@ use function count;
 use function explode;
 use function implode;
 use function in_array;
+use function sprintf;
 use function str_replace;
 
 final class Location implements LocationInterface
@@ -49,9 +50,14 @@ final class Location implements LocationInterface
         return new self($id, $folder->getName());
     }
 
-    public static function createAsSection(string $type, ?string $sectionName = null): self
+    public static function createAsSection(string $type, ?string $sectionName = null, ?string $folder = null): self
     {
-        return new self($type, $sectionName);
+        return new self(
+            id: $folder !== null
+                ? sprintf('%s||%s', $type, str_replace('/', '|', $folder))
+                : $type,
+            name: $sectionName ?? $type,
+        );
     }
 
     public function getLocationId(): string

--- a/lib/ContentBrowser/Item/RemoteMedia/Location.php
+++ b/lib/ContentBrowser/Item/RemoteMedia/Location.php
@@ -53,10 +53,10 @@ final class Location implements LocationInterface
     public static function createAsSection(string $type, ?string $sectionName = null, ?string $folder = null): self
     {
         return new self(
-            id: $folder !== null
+            $folder !== null
                 ? sprintf('%s||%s', $type, str_replace('/', '|', $folder))
                 : $type,
-            name: $sectionName ?? $type,
+            $sectionName ?? $type,
         );
     }
 

--- a/tests/bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/bundle/DependencyInjection/ConfigurationTest.php
@@ -24,6 +24,7 @@ final class ConfigurationTest extends TestCase
                         'pool' => 'cache.app',
                         'ttl' => 7200,
                     ],
+                    'root_folder' => 'images/layouts',
                 ],
             ],
         );

--- a/tests/bundle/DependencyInjection/NetgenLayoutsRemoteMediaExtensionTest.php
+++ b/tests/bundle/DependencyInjection/NetgenLayoutsRemoteMediaExtensionTest.php
@@ -18,6 +18,7 @@ final class NetgenLayoutsRemoteMediaExtensionTest extends AbstractExtensionTestC
 
         $this->assertContainerBuilderHasParameter('netgen_layouts.remote_media.cache.pool_name', 'cache.redis');
         $this->assertContainerBuilderHasParameter('netgen_layouts.remote_media.cache.ttl', 4800);
+        $this->assertContainerBuilderHasParameter('netgen_layouts.remote_media.root_folder', 'images/layouts');
     }
 
     protected function getContainerExtensions(): array
@@ -37,6 +38,7 @@ final class NetgenLayoutsRemoteMediaExtensionTest extends AbstractExtensionTestC
                 'pool' => 'cache.redis',
                 'ttl' => 4800,
             ],
+            'root_folder' => 'images/layouts',
         ];
     }
 }

--- a/tests/bundle/DependencyInjection/NetgenLayoutsRemoteMediaExtensionTest.php
+++ b/tests/bundle/DependencyInjection/NetgenLayoutsRemoteMediaExtensionTest.php
@@ -29,7 +29,7 @@ final class NetgenLayoutsRemoteMediaExtensionTest extends AbstractExtensionTestC
     }
 
     /**
-     * @return array<string,array<string, mixed>>
+     * @return array<string, mixed>
      */
     protected function getMinimalConfiguration(): array
     {

--- a/tests/lib/ContentBrowser/Backend/RemoteMediaBackendTest.php
+++ b/tests/lib/ContentBrowser/Backend/RemoteMediaBackendTest.php
@@ -132,6 +132,39 @@ final class RemoteMediaBackendTest extends TestCase
         self::assertContainsOnlyInstancesOf(Location::class, $sections);
     }
 
+    public function testGetSectionsWithRootFolder(): void
+    {
+        $this->backend = new RemoteMediaBackend(
+            $this->providerMock,
+            $this->nextCursorResolverMock,
+            $this->translatorMock,
+            $this->config,
+            'images/layouts',
+        );
+
+        $this->translatorMock
+            ->expects(self::exactly(6))
+            ->method('trans')
+            ->willReturnMap(
+                [
+                    ['backend.remote_media.resource_type.all', [], 'ngcb', null, 'All resources'],
+                    ['backend.remote_media.resource_type.image', [], 'ngcb', null, 'Image'],
+                    ['backend.remote_media.resource_type.audio', [], 'ngcb', null, 'Audio'],
+                    ['backend.remote_media.resource_type.video', [], 'ngcb', null, 'Video'],
+                    ['backend.remote_media.resource_type.document', [], 'ngcb', null, 'Document'],
+                    ['backend.remote_media.resource_type.other', [], 'ngcb', null, 'Other'],
+                ],
+            );
+
+        $sections = $this->backend->getSections();
+
+        self::assertCount(6, $sections);
+        self::assertContainsOnlyInstancesOf(Location::class, $sections);
+
+        self::assertSame('all||images|layouts', $sections[0]->getLocationId());
+        self::assertSame('image||images|layouts', $sections[1]->getLocationId());
+    }
+
     public function testLoadLocation(): void
     {
         $location = $this->backend->loadLocation('video||media|videos');

--- a/tests/lib/ContentBrowser/Backend/RemoteMediaBackendTest.php
+++ b/tests/lib/ContentBrowser/Backend/RemoteMediaBackendTest.php
@@ -156,6 +156,7 @@ final class RemoteMediaBackendTest extends TestCase
                 ],
             );
 
+        /** @var \Netgen\Layouts\RemoteMedia\ContentBrowser\Item\RemoteMedia\Location[] $sections */
         $sections = $this->backend->getSections();
 
         self::assertCount(6, $sections);

--- a/tests/lib/ContentBrowser/Item/RemoteMedia/LocationTest.php
+++ b/tests/lib/ContentBrowser/Item/RemoteMedia/LocationTest.php
@@ -75,6 +75,17 @@ final class LocationTest extends TestCase
         self::assertSame('video', $this->location->getType());
     }
 
+    public function testCreateAsSectionWithFolder(): void
+    {
+        $location = Location::createAsSection('image', 'Images', 'images/layouts');
+
+        self::assertSame('image||images|layouts', $location->getLocationId());
+        self::assertSame('Images', $location->getName());
+        self::assertSame('image', $location->getType());
+        self::assertInstanceOf(Folder::class, $location->getFolder());
+        self::assertSame('images/layouts', $location->getFolder()->getPath());
+    }
+
     public function testFromIdWithInvalidResourceType(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
https://github.com/netgen-layouts/layouts-remote-media/pull/16 Randy already implemented this for v1, this is a port for v2. 

Randy: "Currently we're having a huge performance issue with Cloudinary, if root folder has a lot of subfolders. For every subfolder, two requests are being executed towards Cloudinary API: one to check if this folder has any subfolders, and one to check if it has files in it.

On some of our projects, this causes timeouts. Until we don't find some more suitable solution, this PR introduces a parameter to limit the tree to specific folder, so that it loads only subfolders and resources which are below that one. But it doesn't prevent usage of resources outside of that folder - you can still find them via search. And previously added resources will still work."
